### PR TITLE
chore: remove bundled image assets

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,82 @@
+// Entry point for the Countdown app. Sets up fonts, providers, and navigation.
+import 'react-native-gesture-handler';
+import React from 'react';
+import { ActivityIndicator, StatusBar, StyleSheet, View } from 'react-native';
+import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { useFonts, PlayfairDisplay_700Bold } from '@expo-google-fonts/playfair-display';
+import { AppProvider, useApp, useThemeMode } from './src/context/AppContext';
+import { HomeScreen } from './src/screens/HomeScreen';
+import { AddEventScreen } from './src/screens/AddEventScreen';
+import { EventScreen } from './src/screens/EventScreen';
+import { SettingsScreen } from './src/screens/SettingsScreen';
+import { RootStackParamList } from './src/navigation/types';
+import { palette } from './src/theme/colors';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const AppNavigator = () => {
+  const { isBootstrapping } = useApp();
+  const themeMode = useThemeMode();
+
+  if (isBootstrapping) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color={palette.accentMist} size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <NavigationContainer theme={themeMode === 'dark' ? DarkTheme : DefaultTheme}>
+      <StatusBar barStyle={themeMode === 'dark' ? 'light-content' : 'dark-content'} />
+      <Stack.Navigator
+        screenOptions={{
+          headerShown: false,
+          animation: 'fade_from_bottom'
+        }}
+      >
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="AddEvent" component={AddEventScreen} />
+        <Stack.Screen name="Event" component={EventScreen} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+const AppContent = () => {
+  const [fontsLoaded] = useFonts({ PlayfairDisplay_700Bold });
+
+  if (!fontsLoaded) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color={palette.accentMist} />
+      </View>
+    );
+  }
+
+  return (
+    <AppProvider>
+      <AppNavigator />
+    </AppProvider>
+  );
+};
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <AppContent />
+    </SafeAreaProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: palette.backgroundDark,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# countdown
+# Countdown — The Time That Slips Away
+
+A contemplative mobile app built with Expo React Native that lets you create emotional countdowns and count-ups for the moments that matter.
+
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the development server
+   ```bash
+   npm run start
+   ```
+3. Use the Expo Go app on iOS or Android to scan the QR code.
+
+## Features
+- Create and pin countdown or count-up events with moods, quotes, and backgrounds.
+- Local storage with AsyncStorage and soft daily/anniversary notifications via Expo Notifications.
+- Share a full-screen countdown as an image.
+- Premium flow scaffolded with Expo In-App Purchases.
+- Settings for notification cadence, theme switching, and premium management.
+
+## Notes
+- Premium purchase resolves instantly for Expo Go testing.
+- Widgets and ambient audio are premium concepts and will be implemented in future iterations.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,39 @@
+{
+  "expo": {
+    "name": "Countdown",
+    "slug": "countdown-time-that-slips-away",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "resizeMode": "contain",
+      "backgroundColor": "#0f1115"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": false
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#0f1115"
+      }
+    },
+    "plugins": [
+      [
+        "expo-notifications",
+        {
+          "color": "#9db4c0"
+        }
+      ],
+      "expo-font"
+    ],
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "runtimeVersion": {
+      "policy": "sdkVersion"
+    }
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin']
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "countdown",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@expo-google-fonts/playfair-display": "~0.2.3",
+    "@react-native-async-storage/async-storage": "~1.21.0",
+    "@react-native-community/datetimepicker": "7.6.2",
+    "@react-navigation/native": "^6.1.11",
+    "@react-navigation/native-stack": "^6.9.20",
+    "date-fns": "^3.6.0",
+    "expo": "~51.0.14",
+    "expo-constants": "~16.0.2",
+    "expo-file-system": "~17.0.1",
+    "expo-font": "~12.0.9",
+    "expo-image-picker": "~15.0.7",
+    "expo-linear-gradient": "~13.0.2",
+    "expo-notifications": "~0.27.6",
+    "expo-sharing": "~12.0.3",
+    "expo-status-bar": "~1.12.1",
+    "expo-updates": "~0.24.12",
+    "expo-web-browser": "~13.0.3",
+    "react": "18.2.0",
+    "react-native": "0.74.3",
+    "react-native-gesture-handler": "~2.16.1",
+    "react-native-reanimated": "~3.10.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~3.31.1",
+    "react-native-view-shot": "^3.8.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.5",
+    "@types/react": "~18.2.45",
+    "@types/react-native": "~0.73.0",
+    "typescript": "~5.4.5"
+  }
+}

--- a/src/components/BackgroundSelector.tsx
+++ b/src/components/BackgroundSelector.tsx
@@ -1,0 +1,88 @@
+// Allows the user to choose a background color or image for an event.
+import React from 'react';
+import { ImageBackground, Pressable, StyleSheet, Text, View } from 'react-native';
+import { EventBackground } from '../types';
+import { palette } from '../theme/colors';
+
+interface Props {
+  value?: EventBackground;
+  onSelectColor: (color: string) => void;
+  onSelectImage?: () => void;
+  canUseImages: boolean;
+}
+
+const swatches = ['#1f242b', '#2c1c29', '#1d2b2a', '#2a233b', '#40302e'];
+
+export const BackgroundSelector: React.FC<Props> = ({ value, onSelectColor, onSelectImage, canUseImages }) => (
+  <View style={styles.container}>
+    <Text style={styles.label}>Background</Text>
+    <View style={styles.swatchRow}>
+      {swatches.map(color => {
+        const isActive = value?.type === 'color' && value.value === color;
+        return (
+          <Pressable
+            key={color}
+            style={[styles.swatch, { backgroundColor: color, borderColor: isActive ? palette.accentMist : 'transparent' }]}
+            onPress={() => onSelectColor(color)}
+          />
+        );
+      })}
+      {canUseImages && onSelectImage ? (
+        <Pressable style={[styles.swatch, styles.imageSwatch]} onPress={onSelectImage}>
+          {value?.type === 'image' ? (
+            <ImageBackground source={{ uri: value.value }} style={StyleSheet.absoluteFill} imageStyle={{ borderRadius: 16 }} />
+          ) : (
+            <Text style={styles.imageText}>Image</Text>
+          )}
+        </Pressable>
+      ) : (
+        <View style={[styles.swatch, styles.lockedSwatch]}>
+          <Text style={styles.lockedText}>Premium</Text>
+        </View>
+      )}
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 12,
+    gap: 12
+  },
+  label: {
+    color: palette.textSecondaryDark,
+    fontSize: 14,
+    letterSpacing: 1,
+    textTransform: 'uppercase'
+  },
+  swatchRow: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap'
+  },
+  swatch: {
+    width: 64,
+    height: 64,
+    borderRadius: 18,
+    borderWidth: 2,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  imageSwatch: {
+    backgroundColor: palette.surfaceDark
+  },
+  imageText: {
+    color: palette.textSecondaryDark,
+    fontSize: 12
+  },
+  lockedSwatch: {
+    borderStyle: 'dashed',
+    borderColor: 'rgba(255,255,255,0.2)'
+  },
+  lockedText: {
+    color: palette.textSecondaryDark,
+    fontSize: 12,
+    textAlign: 'center',
+    paddingHorizontal: 6
+  }
+});

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,115 @@
+// Card used on the home screen to present a single countdown in the list.
+import React, { useEffect, useRef } from 'react';
+import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { CountdownEvent } from '../types';
+import { getCountdownText, getProgressToEvent } from '../utils/time';
+import { palette } from '../theme/colors';
+import { typography } from '../theme/typography';
+
+interface Props {
+  event: CountdownEvent;
+  onPress: () => void;
+}
+
+export const EventCard: React.FC<Props> = ({ event, onPress }) => {
+  const progress = getProgressToEvent(event.createdAt, event.date, event.mode);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 600,
+      useNativeDriver: true
+    }).start();
+  }, [fadeAnim]);
+
+  const moodAccent = event.mood === 'Hopeful'
+    ? palette.accentEmerald
+    : event.mood === 'Melancholy'
+      ? palette.accentMist
+      : event.mood === 'Peaceful'
+        ? palette.accentGold
+        : palette.accentMist;
+
+  return (
+    <Animated.View style={[styles.container, { opacity: fadeAnim }]}> 
+      <Pressable style={styles.pressable} onPress={onPress} android_ripple={{ color: 'rgba(255,255,255,0.05)' }}>
+        <View style={styles.headerRow}>
+          <View style={styles.titleContainer}>
+            <Text style={[styles.title, { color: palette.textPrimaryDark }]} numberOfLines={1}>
+              {event.title}
+            </Text>
+            {event.pinned && <Text style={styles.pinned}>Pinned</Text>}
+          </View>
+          <Text style={[styles.countdown, { color: moodAccent }]}>{getCountdownText(event.date, event.mode)}</Text>
+        </View>
+        <View style={styles.progressBar}> 
+          <LinearGradient
+            colors={[moodAccent, 'rgba(255,255,255,0.05)']}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={[StyleSheet.absoluteFill, { width: `${Math.max(progress * 100, 2)}%`, borderRadius: 6 }]}
+          />
+        </View>
+        {event.quote ? (
+          <Text style={styles.quote} numberOfLines={2}>
+            “{event.quote}”
+          </Text>
+        ) : null}
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: palette.surfaceDark,
+    borderRadius: 20,
+    padding: 20,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 4
+  },
+  pressable: {
+    gap: 16
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  titleContainer: {
+    flex: 1,
+    paddingRight: 12
+  },
+  title: {
+    ...typography.titleSerif
+  },
+  pinned: {
+    marginTop: 4,
+    fontSize: 12,
+    letterSpacing: 1,
+    color: palette.textSecondaryDark,
+    textTransform: 'uppercase'
+  },
+  countdown: {
+    fontFamily: 'System',
+    fontSize: 16,
+    textAlign: 'right'
+  },
+  progressBar: {
+    height: 8,
+    backgroundColor: palette.divider,
+    borderRadius: 6,
+    overflow: 'hidden'
+  },
+  quote: {
+    ...typography.body,
+    color: palette.textSecondaryDark,
+    fontStyle: 'italic'
+  }
+});

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -1,0 +1,38 @@
+// Minimal floating action button used for adding new events.
+import React from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { palette } from '../theme/colors';
+
+interface Props {
+  onPress: () => void;
+}
+
+export const FloatingActionButton: React.FC<Props> = ({ onPress }) => (
+  <Pressable style={styles.button} onPress={onPress} android_ripple={{ color: 'rgba(0,0,0,0.2)', borderless: true }}>
+    <Text style={styles.label}>＋</Text>
+  </Pressable>
+);
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    bottom: 32,
+    right: 24,
+    backgroundColor: palette.accentMist,
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.25,
+    shadowOffset: { width: 0, height: 12 },
+    shadowRadius: 16,
+    elevation: 6
+  },
+  label: {
+    color: palette.backgroundDark,
+    fontSize: 36,
+    fontWeight: '600'
+  }
+});

--- a/src/components/MoodSelector.tsx
+++ b/src/components/MoodSelector.tsx
@@ -1,0 +1,67 @@
+// Mood selector component used in the add event form.
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Mood } from '../types';
+import { palette } from '../theme/colors';
+import { typography } from '../theme/typography';
+
+interface Props {
+  moods: Mood[];
+  selected: Mood;
+  onSelect: (mood: Mood) => void;
+}
+
+const moodLabels: Record<Mood, string> = {
+  Hopeful: 'Hopeful',
+  Melancholy: 'Melancholy',
+  Peaceful: 'Peaceful',
+  Silent: 'Silent'
+};
+
+export const MoodSelector: React.FC<Props> = ({ moods, selected, onSelect }) => (
+  <View style={styles.container}>
+    {(['Hopeful', 'Melancholy', 'Peaceful', 'Silent'] as Mood[]).map(mood => {
+      const enabled = moods.includes(mood);
+      const isActive = selected === mood;
+      const backgroundColor = isActive ? palette.surfaceDark : 'transparent';
+      const borderColor = enabled ? palette.accentMist : 'rgba(255,255,255,0.15)';
+      const textColor = enabled ? palette.textPrimaryDark : palette.textSecondaryDark;
+      return (
+        <Pressable
+          key={mood}
+          disabled={!enabled}
+          onPress={() => onSelect(mood)}
+          style={[styles.pill, { borderColor, backgroundColor, opacity: enabled ? 1 : 0.4 }]}
+        >
+          <Text style={[styles.label, { color: textColor }]}>{moodLabels[mood]}</Text>
+          {!enabled && <Text style={styles.locked}>Premium</Text>}
+        </Pressable>
+      );
+    })}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12
+  },
+  pill: {
+    borderWidth: 1,
+    borderRadius: 24,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    minWidth: '42%'
+  },
+  label: {
+    ...typography.body,
+    textAlign: 'center'
+  },
+  locked: {
+    marginTop: 4,
+    fontSize: 10,
+    color: palette.textSecondaryDark,
+    textAlign: 'center'
+  }
+});

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,0 +1,166 @@
+// Global context that orchestrates events, settings, and premium status.
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { CountdownEvent, CountdownState, EventMode, Mood, NotificationPreference } from '../types';
+import { loadEvents, saveEvents } from '../storage/eventStorage';
+import { defaultSettings, loadSettings, saveSettings } from '../storage/settingsStorage';
+import { cancelNotificationsForEvent, scheduleNotificationsForEvent } from '../services/notificationService';
+import { purchasePremium, restorePremium } from '../services/PremiumService';
+
+interface AppContextValue extends CountdownState {
+  isBootstrapping: boolean;
+  addEvent: (event: Omit<CountdownEvent, 'id' | 'createdAt' | 'pinned'>) => Promise<void>;
+  updateEvent: (id: string, changes: Partial<CountdownEvent>) => Promise<void>;
+  removeEvent: (id: string) => Promise<void>;
+  togglePin: (id: string) => Promise<void>;
+  availableMoods: Mood[];
+  setNotificationPreference: (preference: NotificationPreference) => Promise<void>;
+  toggleTheme: () => Promise<void>;
+  unlockPremium: () => Promise<boolean>;
+  restorePremiumAccess: () => Promise<boolean>;
+}
+
+const AppContext = createContext<AppContextValue | undefined>(undefined);
+
+export const AppProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [events, setEvents] = useState<CountdownEvent[]>([]);
+  const [settings, setSettings] = useState(defaultSettings);
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const [loadedEvents, loadedSettings] = await Promise.all([loadEvents(), loadSettings()]);
+      setEvents(loadedEvents);
+      setSettings(loadedSettings);
+      setIsBootstrapping(false);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!isBootstrapping) {
+      saveEvents(events).catch(err => console.warn('Failed saving events', err));
+    }
+  }, [events, isBootstrapping]);
+
+  useEffect(() => {
+    if (!isBootstrapping) {
+      saveSettings(settings).catch(err => console.warn('Failed saving settings', err));
+    }
+  }, [settings, isBootstrapping]);
+
+  const addEvent = useCallback(async (event: Omit<CountdownEvent, 'id' | 'createdAt' | 'pinned'>) => {
+    const newEvent: CountdownEvent = {
+      ...event,
+      id: `${Date.now()}`,
+      createdAt: new Date().toISOString(),
+      pinned: false
+    };
+    setEvents(prev => [newEvent, ...prev]);
+    await scheduleNotificationsForEvent(newEvent, settings.notificationPreference);
+  }, [settings.notificationPreference]);
+
+  const updateEvent = useCallback(async (id: string, changes: Partial<CountdownEvent>) => {
+    let merged: CountdownEvent | undefined;
+    setEvents(prev => prev.map(event => {
+      if (event.id === id) {
+        merged = { ...event, ...changes } as CountdownEvent;
+        return merged;
+      }
+      return event;
+    }));
+    if (merged) {
+      await scheduleNotificationsForEvent(merged, settings.notificationPreference);
+    }
+  }, [settings.notificationPreference]);
+
+  const removeEvent = useCallback(async (id: string) => {
+    setEvents(prev => prev.filter(event => event.id !== id));
+    await cancelNotificationsForEvent(id);
+  }, []);
+
+  const togglePin = useCallback(async (id: string) => {
+    setEvents(prev => prev.map(event => (event.id === id ? { ...event, pinned: !event.pinned } : event)));
+  }, []);
+
+  const setNotificationPreference = useCallback(async (preference: NotificationPreference) => {
+    setSettings(prev => ({ ...prev, notificationPreference: preference }));
+    const updatedEvents = events;
+    await Promise.all(updatedEvents.map(event => scheduleNotificationsForEvent(event, preference)));
+  }, [events]);
+
+  const toggleTheme = useCallback(async () => {
+    setSettings(prev => ({ ...prev, theme: prev.theme === 'dark' ? 'light' : 'dark' }));
+  }, []);
+
+  const unlockPremium = useCallback(async () => {
+    const success = await purchasePremium();
+    if (success) {
+      setSettings(prev => ({ ...prev, premiumUnlocked: true }));
+    }
+    return success;
+  }, []);
+
+  const restorePremiumAccess = useCallback(async () => {
+    const restored = await restorePremium();
+    if (restored) {
+      setSettings(prev => ({ ...prev, premiumUnlocked: true }));
+    }
+    return restored;
+  }, []);
+
+  const availableMoods = useMemo<Mood[]>(() => {
+    if (settings.premiumUnlocked) {
+      return ['Hopeful', 'Melancholy', 'Peaceful', 'Silent'];
+    }
+    return ['Hopeful', 'Melancholy'];
+  }, [settings.premiumUnlocked]);
+
+  const value = useMemo<AppContextValue>(() => ({
+    events,
+    settings,
+    isBootstrapping,
+    addEvent,
+    updateEvent,
+    removeEvent,
+    togglePin,
+    availableMoods,
+    setNotificationPreference,
+    toggleTheme,
+    unlockPremium,
+    restorePremiumAccess
+  }), [
+    addEvent,
+    availableMoods,
+    events,
+    isBootstrapping,
+    removeEvent,
+    restorePremiumAccess,
+    setNotificationPreference,
+    settings,
+    togglePin,
+    toggleTheme,
+    unlockPremium,
+    updateEvent
+  ]);
+
+  return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
+};
+
+export const useApp = () => {
+  const ctx = useContext(AppContext);
+  if (!ctx) {
+    throw new Error('useApp must be used within AppProvider');
+  }
+  return ctx;
+};
+
+export const useThemeMode = () => {
+  const { settings } = useApp();
+  return settings.theme;
+};
+
+export const usePremiumUnlocked = () => {
+  const { settings } = useApp();
+  return settings.premiumUnlocked;
+};
+
+export const isMoodAvailable = (mood: Mood, available: Mood[]): boolean => available.includes(mood);

--- a/src/hooks/useCountdownTimer.ts
+++ b/src/hooks/useCountdownTimer.ts
@@ -1,0 +1,21 @@
+// Hook that provides a ticking string representation for the event detail screen.
+import { useEffect, useState } from 'react';
+import { EventMode } from '../types';
+import { describeTimeDelta, getCountdownText } from '../utils/time';
+
+export const useCountdownTimer = (date: string, mode: EventMode) => {
+  const [primaryText, setPrimaryText] = useState(() => getCountdownText(date, mode));
+  const [secondaryText, setSecondaryText] = useState(() => describeTimeDelta(date, mode));
+
+  useEffect(() => {
+    setPrimaryText(getCountdownText(date, mode));
+    setSecondaryText(describeTimeDelta(date, mode));
+    const interval = setInterval(() => {
+      setPrimaryText(getCountdownText(date, mode));
+      setSecondaryText(describeTimeDelta(date, mode));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [date, mode]);
+
+  return { primaryText, secondaryText };
+};

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,9 @@
+// Shared navigation type definitions for the stack navigator.
+import { CountdownEvent } from '../types';
+
+export type RootStackParamList = {
+  Home: undefined;
+  AddEvent: { event?: CountdownEvent } | undefined;
+  Event: { eventId: string };
+  Settings: undefined;
+};

--- a/src/screens/AddEventScreen.tsx
+++ b/src/screens/AddEventScreen.tsx
@@ -1,0 +1,265 @@
+// Screen containing the form for creating or editing a countdown event.
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View
+} from 'react-native';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import * as ImagePicker from 'expo-image-picker';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { BackgroundSelector } from '../components/BackgroundSelector';
+import { MoodSelector } from '../components/MoodSelector';
+import { useApp, usePremiumUnlocked } from '../context/AppContext';
+import { palette } from '../theme/colors';
+import { typography } from '../theme/typography';
+import { EventBackground, EventMode, Mood } from '../types';
+import { RootStackParamList } from '../navigation/types';
+
+export type AddEventScreenProps = NativeStackScreenProps<RootStackParamList, 'AddEvent'>;
+
+export const AddEventScreen: React.FC<AddEventScreenProps> = ({ navigation, route }) => {
+  const { event } = route.params ?? {};
+  const { addEvent, updateEvent, availableMoods } = useApp();
+  const premiumUnlocked = usePremiumUnlocked();
+  const [title, setTitle] = useState(event?.title ?? '');
+  const [quote, setQuote] = useState(event?.quote ?? '');
+  const [date, setDate] = useState(() => (event ? new Date(event.date) : new Date()));
+  const [mode, setMode] = useState<EventMode>(event?.mode ?? 'countdown');
+  const [mood, setMood] = useState<Mood>(event?.mood ?? availableMoods[0]);
+  const [background, setBackground] = useState<EventBackground | undefined>(event?.background);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showTimePicker, setShowTimePicker] = useState(false);
+  const canUseImages = premiumUnlocked;
+
+  useEffect(() => {
+    if (!availableMoods.includes(mood)) {
+      setMood(availableMoods[0]);
+    }
+  }, [availableMoods, mood]);
+
+  const titleLabel = useMemo(() => (event ? 'Update Countdown' : 'New Countdown'), [event]);
+
+  const onChangeDate = (_: DateTimePickerEvent, selected?: Date) => {
+    if (selected) {
+      setDate(selected);
+    }
+    setShowDatePicker(false);
+  };
+
+  const onChangeTime = (_: DateTimePickerEvent, selected?: Date) => {
+    if (selected) {
+      const newDate = new Date(date);
+      newDate.setHours(selected.getHours());
+      newDate.setMinutes(selected.getMinutes());
+      setDate(newDate);
+    }
+    setShowTimePicker(false);
+  };
+
+  const handleSelectImage = async () => {
+    const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!granted) {
+      Alert.alert('Permission required', 'Allow photo access to set a background image.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.7 });
+    if (!result.canceled && result.assets?.length) {
+      setBackground({ type: 'image', value: result.assets[0].uri });
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      Alert.alert('Title missing', 'Name this moment so it can be remembered.');
+      return;
+    }
+    const payload = {
+      title: title.trim(),
+      quote: quote.trim() ? quote.trim() : undefined,
+      date: date.toISOString(),
+      mode,
+      mood,
+      background
+    };
+    if (event) {
+      await updateEvent(event.id, { ...payload, createdAt: event.createdAt });
+    } else {
+      await addEvent(payload);
+    }
+    navigation.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container} showsVerticalScrollIndicator={false}>
+        <Text style={styles.heading}>{titleLabel}</Text>
+        <View style={styles.field}>
+          <Text style={styles.label}>Title</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="A birth, a goodbye, a quiet change..."
+            placeholderTextColor={'rgba(255,255,255,0.3)'}
+            value={title}
+            onChangeText={setTitle}
+          />
+        </View>
+        <View style={styles.inlineRow}>
+          <View style={[styles.field, styles.inlineItem]}>
+            <Text style={styles.label}>Date</Text>
+            <Pressable style={styles.selector} onPress={() => setShowDatePicker(true)}>
+              <Text style={styles.selectorText}>{date.toDateString()}</Text>
+            </Pressable>
+          </View>
+          <View style={[styles.field, styles.inlineItem]}>
+            <Text style={styles.label}>Time</Text>
+            <Pressable style={styles.selector} onPress={() => setShowTimePicker(true)}>
+              <Text style={styles.selectorText}>
+                {date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+        {(showDatePicker || showTimePicker) && (
+          <DateTimePicker
+            value={date}
+            mode={showDatePicker ? 'date' : 'time'}
+            onChange={showDatePicker ? onChangeDate : onChangeTime}
+            display={Platform.OS === 'ios' ? 'inline' : 'default'}
+          />
+        )}
+        <View style={styles.field}>
+          <Text style={styles.label}>Mode</Text>
+          <View style={styles.modeRow}>
+            {(['countdown', 'countup'] as EventMode[]).map(option => (
+              <Pressable
+                key={option}
+                style={[styles.modeButton, mode === option && styles.modeButtonActive]}
+                onPress={() => setMode(option)}
+              >
+                <Text style={[styles.modeText, mode === option && styles.modeTextActive]}>
+                  {option === 'countdown' ? 'Counting down' : 'Counting up'}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+        <View style={styles.field}>
+          <Text style={styles.label}>Quote (optional)</Text>
+          <TextInput
+            style={[styles.input, styles.multiline]}
+            placeholder="Words that stay with you"
+            placeholderTextColor={'rgba(255,255,255,0.3)'}
+            value={quote}
+            onChangeText={setQuote}
+            multiline
+            numberOfLines={3}
+          />
+        </View>
+        <BackgroundSelector
+          value={background}
+          onSelectColor={color => setBackground({ type: 'color', value: color })}
+          onSelectImage={canUseImages ? handleSelectImage : undefined}
+          canUseImages={canUseImages}
+        />
+        <View style={styles.field}>
+          <Text style={styles.label}>Mood</Text>
+          <MoodSelector moods={availableMoods} selected={mood} onSelect={setMood} />
+        </View>
+        <Pressable style={styles.saveButton} onPress={handleSubmit}>
+          <Text style={styles.saveButtonText}>{event ? 'Save changes' : 'Save countdown'}</Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.backgroundDark
+  },
+  container: {
+    padding: 24,
+    paddingBottom: 120,
+    gap: 24
+  },
+  heading: {
+    ...typography.headlineSerif,
+    color: palette.textPrimaryDark
+  },
+  field: {
+    gap: 12
+  },
+  label: {
+    color: palette.textSecondaryDark,
+    fontSize: 14,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase'
+  },
+  input: {
+    backgroundColor: palette.surfaceDark,
+    borderRadius: 16,
+    padding: 16,
+    color: palette.textPrimaryDark,
+    ...typography.body
+  },
+  multiline: {
+    minHeight: 120,
+    textAlignVertical: 'top'
+  },
+  inlineRow: {
+    flexDirection: 'row',
+    gap: 12
+  },
+  inlineItem: {
+    flex: 1
+  },
+  selector: {
+    backgroundColor: palette.surfaceDark,
+    borderRadius: 16,
+    padding: 16
+  },
+  selectorText: {
+    color: palette.textPrimaryDark
+  },
+  modeRow: {
+    flexDirection: 'row',
+    gap: 12
+  },
+  modeButton: {
+    flex: 1,
+    borderRadius: 16,
+    paddingVertical: 16,
+    backgroundColor: palette.surfaceDark
+  },
+  modeButtonActive: {
+    backgroundColor: '#242933'
+  },
+  modeText: {
+    textAlign: 'center',
+    color: palette.textSecondaryDark
+  },
+  modeTextActive: {
+    color: palette.textPrimaryDark,
+    fontWeight: '600'
+  },
+  saveButton: {
+    marginTop: 12,
+    backgroundColor: palette.accentMist,
+    borderRadius: 18,
+    paddingVertical: 18
+  },
+  saveButtonText: {
+    textAlign: 'center',
+    color: palette.backgroundDark,
+    fontSize: 16,
+    letterSpacing: 1.2
+  }
+});

--- a/src/screens/EventScreen.tsx
+++ b/src/screens/EventScreen.tsx
@@ -1,0 +1,156 @@
+// Detailed view of a single event with animated countdown text and sharing capabilities.
+import React, { useMemo, useRef } from 'react';
+import { ImageBackground, Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import ViewShot from 'react-native-view-shot';
+import * as Sharing from 'expo-sharing';
+import { useApp } from '../context/AppContext';
+import { palette } from '../theme/colors';
+import { typography } from '../theme/typography';
+import { RootStackParamList } from '../navigation/types';
+import { useCountdownTimer } from '../hooks/useCountdownTimer';
+
+export type EventScreenProps = NativeStackScreenProps<RootStackParamList, 'Event'>;
+
+export const EventScreen: React.FC<EventScreenProps> = ({ route }) => {
+  const { eventId } = route.params;
+  const { events, togglePin } = useApp();
+  const event = useMemo(() => events.find(item => item.id === eventId), [events, eventId]);
+  const viewShotRef = useRef<ViewShot | null>(null);
+
+  const { primaryText, secondaryText } = useCountdownTimer(event?.date ?? new Date().toISOString(), event?.mode ?? 'countdown');
+
+  if (!event) {
+    return (
+      <SafeAreaView style={[styles.safeArea, { justifyContent: 'center', alignItems: 'center' }]}> 
+        <Text style={styles.missing}>This moment could not be found.</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const handleShare = async () => {
+    try {
+      const uri = await viewShotRef.current?.capture?.();
+      if (uri) {
+        await Sharing.shareAsync(uri);
+      }
+    } catch (error) {
+      console.warn('Failed to share countdown', error);
+    }
+  };
+
+  const backgroundStyle = event.background?.type === 'color'
+    ? { backgroundColor: event.background.value }
+    : { backgroundColor: palette.backgroundDark };
+
+  const content = (
+    <ViewShot ref={viewShotRef} style={styles.captureArea} options={{ format: 'png', quality: 0.9 }}>
+      <View style={[styles.content, backgroundStyle]}>
+        {event.background?.type === 'image' ? (
+          <ImageBackground source={{ uri: event.background.value }} style={styles.imageBackground} imageStyle={{ opacity: 0.8 }}>
+            <View style={styles.overlay}>
+              <Text style={styles.title}>{event.title}</Text>
+              <Text style={styles.primary}>{primaryText}</Text>
+              <Text style={styles.secondary}>{secondaryText}</Text>
+              {event.quote ? <Text style={styles.quote}>“{event.quote}”</Text> : null}
+            </View>
+          </ImageBackground>
+        ) : (
+          <View style={styles.overlay}>
+            <Text style={styles.title}>{event.title}</Text>
+            <Text style={styles.primary}>{primaryText}</Text>
+            <Text style={styles.secondary}>{secondaryText}</Text>
+            {event.quote ? <Text style={styles.quote}>“{event.quote}”</Text> : null}
+          </View>
+        )}
+      </View>
+    </ViewShot>
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      {content}
+      <View style={styles.footerActions}>
+        <Pressable style={styles.footerButton} onPress={handleShare}>
+          <Text style={styles.footerButtonText}>Share</Text>
+        </Pressable>
+        <Pressable style={styles.footerButton} onPress={() => togglePin(event.id)}>
+          <Text style={styles.footerButtonText}>{event.pinned ? 'Unpin' : 'Pin'}</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.backgroundDark
+  },
+  captureArea: {
+    flex: 1
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24
+  },
+  overlay: {
+    backgroundColor: 'rgba(15, 17, 21, 0.55)',
+    borderRadius: 32,
+    padding: 32,
+    alignItems: 'center',
+    gap: 16
+  },
+  imageBackground: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  title: {
+    ...typography.headlineSerif,
+    color: palette.textPrimaryDark,
+    textAlign: 'center'
+  },
+  primary: {
+    fontSize: 48,
+    fontFamily: 'PlayfairDisplay_700Bold',
+    color: palette.textPrimaryDark,
+    textAlign: 'center'
+  },
+  secondary: {
+    ...typography.bodyLarge,
+    color: palette.textSecondaryDark,
+    textAlign: 'center'
+  },
+  quote: {
+    ...typography.body,
+    fontStyle: 'italic',
+    color: palette.textSecondaryDark,
+    textAlign: 'center'
+  },
+  footerActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+    padding: 24,
+    gap: 16
+  },
+  footerButton: {
+    flex: 1,
+    backgroundColor: palette.surfaceDark,
+    borderRadius: 18,
+    paddingVertical: 16
+  },
+  footerButtonText: {
+    textAlign: 'center',
+    color: palette.textPrimaryDark,
+    fontSize: 16,
+    letterSpacing: 1.1
+  },
+  missing: {
+    color: palette.textSecondaryDark,
+    ...typography.body
+  }
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,110 @@
+// Home screen listing all countdown events with a floating action button for adding new ones.
+import React, { useMemo } from 'react';
+import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
+import { EventCard } from '../components/EventCard';
+import { FloatingActionButton } from '../components/FloatingActionButton';
+import { useApp } from '../context/AppContext';
+import { palette } from '../theme/colors';
+import { typography } from '../theme/typography';
+import { RootStackParamList } from '../navigation/types';
+
+export type HomeScreenProps = NativeStackScreenProps<RootStackParamList, 'Home'>;
+
+export const HomeScreen: React.FC<HomeScreenProps> = () => {
+  const navigation = useNavigation<HomeScreenProps['navigation']>();
+  const { events } = useApp();
+
+  const sortedEvents = useMemo(
+    () => [...events].sort((a, b) => {
+      if (a.pinned && !b.pinned) {
+        return -1;
+      }
+      if (!a.pinned && b.pinned) {
+        return 1;
+      }
+      return new Date(a.date).getTime() - new Date(b.date).getTime();
+    }),
+    [events]
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.header}>
+        <View>
+          <Text style={styles.title}>Moments we are holding</Text>
+          <Text style={styles.subtitle}>Let time speak softly.</Text>
+        </View>
+        <Text style={styles.settingsLink} onPress={() => navigation.navigate('Settings')}>
+          Settings
+        </Text>
+      </View>
+      <FlatList
+        data={sortedEvents}
+        keyExtractor={item => item.id}
+        contentContainerStyle={sortedEvents.length === 0 ? styles.emptyContainer : styles.listContent}
+        renderItem={({ item }) => (
+          <EventCard event={item} onPress={() => navigation.navigate('Event', { eventId: item.id })} />
+        )}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No countdowns yet.</Text>
+            <Text style={styles.emptyBody}>Create one to honor the moments slipping away.</Text>
+          </View>
+        }
+        showsVerticalScrollIndicator={false}
+      />
+      <FloatingActionButton onPress={() => navigation.navigate('AddEvent')} />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.backgroundDark,
+    paddingHorizontal: 20
+  },
+  header: {
+    paddingTop: 12,
+    paddingBottom: 24,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  title: {
+    ...typography.headlineSerif,
+    color: palette.textPrimaryDark
+  },
+  subtitle: {
+    marginTop: 6,
+    color: palette.textSecondaryDark
+  },
+  settingsLink: {
+    color: palette.accentMist,
+    fontSize: 14,
+    letterSpacing: 1.2
+  },
+  listContent: {
+    paddingBottom: 120
+  },
+  emptyContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingBottom: 120
+  },
+  emptyState: {
+    alignItems: 'center',
+    gap: 8
+  },
+  emptyTitle: {
+    ...typography.titleSerif,
+    color: palette.textPrimaryDark
+  },
+  emptyBody: {
+    ...typography.body,
+    color: palette.textSecondaryDark,
+    textAlign: 'center'
+  }
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,208 @@
+// Settings screen to manage notifications, theme, and premium unlock.
+import React from 'react';
+import { Alert, Pressable, SafeAreaView, ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useApp, usePremiumUnlocked } from '../context/AppContext';
+import { palette } from '../theme/colors';
+import { typography } from '../theme/typography';
+import { NotificationPreference } from '../types';
+import { RootStackParamList } from '../navigation/types';
+
+export type SettingsScreenProps = NativeStackScreenProps<RootStackParamList, 'Settings'>;
+
+const notificationOptions: { label: string; value: NotificationPreference; description: string }[] = [
+  { label: 'Daily whisper', value: 'daily', description: 'A soft daily reminder at dawn.' },
+  { label: 'Final day', value: 'final', description: 'Only when the last day arrives.' },
+  { label: 'Anniversary', value: 'anniversary', description: 'Once each year when the date returns.' },
+  { label: 'Silence', value: 'none', description: 'No notifications.' }
+];
+
+export const SettingsScreen: React.FC<SettingsScreenProps> = () => {
+  const {
+    settings,
+    setNotificationPreference,
+    toggleTheme,
+    unlockPremium,
+    restorePremiumAccess,
+    events
+  } = useApp();
+  const premiumUnlocked = usePremiumUnlocked();
+
+  const handleNotificationChange = async (value: NotificationPreference) => {
+    await setNotificationPreference(value);
+  };
+
+  const handlePurchase = async () => {
+    const success = await unlockPremium();
+    Alert.alert(success ? 'Thank you' : 'Not available', success ? 'Premium is now unlocked.' : 'Purchase could not be completed.');
+  };
+
+  const handleRestore = async () => {
+    const restored = await restorePremiumAccess();
+    Alert.alert(restored ? 'Welcome back' : 'Nothing to restore', restored ? 'Premium features are active.' : 'No previous purchase found.');
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.heading}>Settings</Text>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Notifications</Text>
+          {notificationOptions.map(option => (
+            <Pressable
+              key={option.value}
+              style={[styles.option, settings.notificationPreference === option.value && styles.optionActive]}
+              onPress={() => handleNotificationChange(option.value)}
+            >
+              <View>
+                <Text style={styles.optionLabel}>{option.label}</Text>
+                <Text style={styles.optionDescription}>{option.description}</Text>
+              </View>
+              <View style={[styles.radio, settings.notificationPreference === option.value && styles.radioActive]} />
+            </Pressable>
+          ))}
+        </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Theme</Text>
+          <Pressable style={styles.option} onPress={toggleTheme}>
+            <View>
+              <Text style={styles.optionLabel}>Dark mode</Text>
+              <Text style={styles.optionDescription}>Switch between dark and light.</Text>
+            </View>
+            <Switch value={settings.theme === 'dark'} onValueChange={toggleTheme} trackColor={{ true: palette.accentMist }} />
+          </Pressable>
+        </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Premium</Text>
+          <Text style={styles.premiumDescription}>
+            Unlock widgets, ambient sound, and all moods. Existing moments: {events.length}.
+          </Text>
+          <Pressable style={[styles.premiumButton, premiumUnlocked && styles.premiumButtonDisabled]} onPress={handlePurchase} disabled={premiumUnlocked}>
+            <Text style={styles.premiumButtonText}>{premiumUnlocked ? 'Premium active' : 'Purchase Premium'}</Text>
+          </Pressable>
+          <Pressable style={styles.restoreButton} onPress={handleRestore}>
+            <Text style={styles.restoreText}>Restore purchase</Text>
+          </Pressable>
+          <View style={styles.featureList}>
+            <Text style={styles.featureItem}>• Home & lock screen widgets</Text>
+            <Text style={styles.featureItem}>• Peaceful & Silent moods</Text>
+            <Text style={styles.featureItem}>• Custom background images</Text>
+            <Text style={styles.featureItem}>• Ambient soundscape</Text>
+          </View>
+        </View>
+        {premiumUnlocked && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Ambient Sound</Text>
+            <Pressable style={styles.option}>
+              <View>
+                <Text style={styles.optionLabel}>Peaceful atmosphere</Text>
+                <Text style={styles.optionDescription}>Coming soon. Soft tones when viewing an event.</Text>
+              </View>
+              <View style={styles.badge}>
+                <Text style={styles.badgeText}>Soon</Text>
+              </View>
+            </Pressable>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.backgroundDark
+  },
+  container: {
+    padding: 24,
+    paddingBottom: 120,
+    gap: 32
+  },
+  heading: {
+    ...typography.headlineSerif,
+    color: palette.textPrimaryDark
+  },
+  section: {
+    gap: 16
+  },
+  sectionTitle: {
+    color: palette.textSecondaryDark,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase'
+  },
+  option: {
+    backgroundColor: palette.surfaceDark,
+    borderRadius: 18,
+    padding: 18,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  optionActive: {
+    borderWidth: 1,
+    borderColor: palette.accentMist
+  },
+  optionLabel: {
+    color: palette.textPrimaryDark,
+    fontSize: 16
+  },
+  optionDescription: {
+    marginTop: 6,
+    color: palette.textSecondaryDark,
+    fontSize: 13
+  },
+  radio: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: palette.textSecondaryDark
+  },
+  radioActive: {
+    borderColor: palette.accentMist,
+    backgroundColor: palette.accentMist
+  },
+  premiumDescription: {
+    color: palette.textSecondaryDark,
+    ...typography.body
+  },
+  premiumButton: {
+    backgroundColor: palette.accentMist,
+    paddingVertical: 16,
+    borderRadius: 20
+  },
+  premiumButtonDisabled: {
+    opacity: 0.5
+  },
+  premiumButtonText: {
+    textAlign: 'center',
+    color: palette.backgroundDark,
+    fontSize: 16,
+    letterSpacing: 1.1
+  },
+  restoreButton: {
+    paddingVertical: 8
+  },
+  restoreText: {
+    textAlign: 'center',
+    color: palette.textSecondaryDark,
+    textDecorationLine: 'underline'
+  },
+  featureList: {
+    gap: 8
+  },
+  featureItem: {
+    color: palette.textSecondaryDark
+  },
+  badge: {
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    borderRadius: 12,
+    paddingVertical: 4,
+    paddingHorizontal: 12
+  },
+  badgeText: {
+    color: palette.textSecondaryDark,
+    fontSize: 12
+  }
+});

--- a/src/services/PremiumService.ts
+++ b/src/services/PremiumService.ts
@@ -1,0 +1,50 @@
+// Minimal in-app purchase wrapper. Uses Expo IAP but resolves immediately for testing in Expo Go.
+import * as InAppPurchases from 'expo-in-app-purchases';
+
+const PRODUCT_ID = 'countdown_premium_unlock';
+
+export const connectToStore = async () => {
+  try {
+    await InAppPurchases.connectAsync();
+  } catch (error) {
+    console.warn('Failed to connect to IAP store', error);
+  }
+};
+
+export const disconnectFromStore = async () => {
+  try {
+    await InAppPurchases.disconnectAsync();
+  } catch (error) {
+    console.warn('Failed to disconnect from IAP store', error);
+  }
+};
+
+export const purchasePremium = async (): Promise<boolean> => {
+  try {
+    await connectToStore();
+    const items = await InAppPurchases.getProductsAsync([PRODUCT_ID]);
+    if (items.results.length > 0) {
+      await InAppPurchases.purchaseItemAsync(PRODUCT_ID);
+    }
+    // Expo Go cannot complete purchases; resolve true for testing.
+    return true;
+  } catch (error) {
+    console.warn('Premium purchase failed', error);
+    return false;
+  } finally {
+    await disconnectFromStore();
+  }
+};
+
+export const restorePremium = async (): Promise<boolean> => {
+  try {
+    await connectToStore();
+    const history = await InAppPurchases.getPurchaseHistoryAsync(false);
+    return history.results?.some(entry => entry.productId === PRODUCT_ID) ?? false;
+  } catch (error) {
+    console.warn('Premium restore failed', error);
+    return false;
+  } finally {
+    await disconnectFromStore();
+  }
+};

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,106 @@
+// Wrapper functions around Expo Notifications for scheduling emotional reminders.
+import * as Notifications from 'expo-notifications';
+import { differenceInDays, isAfter } from 'date-fns';
+import { CountdownEvent, NotificationPreference } from '../types';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+    shouldShowAlert: true
+  })
+});
+
+export const requestNotificationPermissions = async (): Promise<boolean> => {
+  const settings = await Notifications.getPermissionsAsync();
+  if (settings.granted || settings.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL) {
+    return true;
+  }
+  const response = await Notifications.requestPermissionsAsync();
+  return response.granted || response.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL;
+};
+
+const createMessage = (event: CountdownEvent): string => {
+  const now = new Date();
+  const target = new Date(event.date);
+  if (event.mode === 'countup') {
+    const days = Math.abs(differenceInDays(now, target));
+    if (days === 0) {
+      return 'Today it began. Breathe.';
+    }
+    return `It has been ${days} day${days === 1 ? '' : 's'} now.`;
+  }
+  if (isAfter(now, target)) {
+    return 'Time moves quietly.';
+  }
+  const daysLeft = differenceInDays(target, now);
+  if (daysLeft <= 0) {
+    return 'Moments remain. Stay with it.';
+  }
+  return `${daysLeft} day${daysLeft === 1 ? '' : 's'} left. Breathe.`;
+};
+
+export const cancelNotificationsForEvent = async (eventId: string) => {
+  const scheduled = await Notifications.getAllScheduledNotificationsAsync();
+  const relevant = scheduled.filter(item => item.content.data?.eventId === eventId);
+  await Promise.all(relevant.map(item => Notifications.cancelScheduledNotificationAsync(item.identifier)));
+};
+
+export const scheduleNotificationsForEvent = async (
+  event: CountdownEvent,
+  preference: NotificationPreference
+) => {
+  await cancelNotificationsForEvent(event.id);
+  const hasPermission = await requestNotificationPermissions();
+  if (!hasPermission || preference === 'none') {
+    return;
+  }
+  const target = new Date(event.date);
+  const now = new Date();
+  if (preference === 'daily') {
+    // Send a daily reminder at 9am local time leading to the event.
+    const trigger = new Date();
+    trigger.setHours(9, 0, 0, 0);
+    if (trigger < now) {
+      trigger.setDate(trigger.getDate() + 1);
+    }
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: event.title,
+        body: createMessage(event),
+        data: { eventId: event.id }
+      },
+      trigger: {
+        hour: 9,
+        minute: 0,
+        repeats: true
+      }
+    });
+  } else if (preference === 'final') {
+    if (target > now) {
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: event.title,
+          body: 'Final day. Hold this moment.',
+          data: { eventId: event.id }
+        },
+        trigger: target
+      });
+    }
+  } else if (preference === 'anniversary') {
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: event.title,
+        body: createMessage(event),
+        data: { eventId: event.id }
+      },
+      trigger: {
+        month: target.getMonth() + 1,
+        day: target.getDate(),
+        hour: 9,
+        minute: 0,
+        repeats: true
+      }
+    });
+  }
+};

--- a/src/storage/eventStorage.ts
+++ b/src/storage/eventStorage.ts
@@ -1,0 +1,22 @@
+// AsyncStorage helpers dedicated to storing and retrieving countdown events.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { CountdownEvent } from '../types';
+import { STORAGE_KEYS } from './storageKeys';
+
+export const loadEvents = async (): Promise<CountdownEvent[]> => {
+  const raw = await AsyncStorage.getItem(STORAGE_KEYS.EVENTS);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as CountdownEvent[];
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored events', error);
+    return [];
+  }
+};
+
+export const saveEvents = async (events: CountdownEvent[]): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEYS.EVENTS, JSON.stringify(events));
+};

--- a/src/storage/settingsStorage.ts
+++ b/src/storage/settingsStorage.ts
@@ -1,0 +1,29 @@
+// AsyncStorage helpers for app-wide settings and premium status.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppSettings } from '../types';
+import { STORAGE_KEYS } from './storageKeys';
+
+export const defaultSettings: AppSettings = {
+  theme: 'dark',
+  notificationPreference: 'daily',
+  premiumUnlocked: false,
+  ambientSound: false
+};
+
+export const loadSettings = async (): Promise<AppSettings> => {
+  const raw = await AsyncStorage.getItem(STORAGE_KEYS.SETTINGS);
+  if (!raw) {
+    return defaultSettings;
+  }
+  try {
+    const parsed = JSON.parse(raw) as AppSettings;
+    return { ...defaultSettings, ...parsed };
+  } catch (error) {
+    console.warn('Failed to parse stored settings', error);
+    return defaultSettings;
+  }
+};
+
+export const saveSettings = async (settings: AppSettings): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEYS.SETTINGS, JSON.stringify(settings));
+};

--- a/src/storage/storageKeys.ts
+++ b/src/storage/storageKeys.ts
@@ -1,0 +1,5 @@
+// Keys used with AsyncStorage for persisting state.
+export const STORAGE_KEYS = {
+  EVENTS: 'countdown.events',
+  SETTINGS: 'countdown.settings'
+};

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,15 @@
+// Palette aligned with the app's emotional, calm aesthetic.
+export const palette = {
+  backgroundDark: '#0f1115',
+  backgroundLight: '#f5f5f2',
+  surfaceDark: '#171a20',
+  surfaceLight: '#ffffff',
+  textPrimaryDark: '#f0f3f5',
+  textSecondaryDark: '#8a93a6',
+  accentEmerald: '#34c9a3',
+  accentGold: '#c9a034',
+  accentMist: '#9db4c0',
+  divider: 'rgba(255,255,255,0.06)'
+} as const;
+
+export type PaletteKey = keyof typeof palette;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,23 @@
+// Typography scales used across the app for consistent large serif presentation.
+export const typography = {
+  titleSerif: {
+    fontFamily: 'PlayfairDisplay_700Bold',
+    fontSize: 28,
+    letterSpacing: 0.5
+  },
+  headlineSerif: {
+    fontFamily: 'PlayfairDisplay_700Bold',
+    fontSize: 40,
+    letterSpacing: 0.4
+  },
+  body: {
+    fontFamily: 'System',
+    fontSize: 16,
+    lineHeight: 22
+  },
+  bodyLarge: {
+    fontFamily: 'System',
+    fontSize: 18,
+    lineHeight: 26
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,37 @@
+// Shared application types for Countdown — The Time That Slips Away.
+// These structures describe events, settings, and premium status used across the app.
+
+export type EventMode = 'countdown' | 'countup';
+
+export type Mood = 'Hopeful' | 'Melancholy' | 'Peaceful' | 'Silent';
+
+export type NotificationPreference = 'daily' | 'final' | 'anniversary' | 'none';
+
+export interface EventBackground {
+  type: 'color' | 'image';
+  value: string; // Hex color or URI depending on the background type.
+}
+
+export interface CountdownEvent {
+  id: string;
+  title: string;
+  date: string; // ISO string for date/time.
+  mode: EventMode;
+  quote?: string;
+  mood: Mood;
+  background?: EventBackground;
+  pinned: boolean;
+  createdAt: string;
+}
+
+export interface AppSettings {
+  theme: 'dark' | 'light';
+  notificationPreference: NotificationPreference;
+  premiumUnlocked: boolean;
+  ambientSound: boolean; // Peaceful ambient background sound toggle for premium users.
+}
+
+export interface CountdownState {
+  events: CountdownEvent[];
+  settings: AppSettings;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,55 @@
+// Utilities for formatting countdown text and calculating progress toward an event.
+import { differenceInDays, differenceInHours, differenceInMinutes, formatDistanceToNowStrict, isPast } from 'date-fns';
+import { EventMode } from '../types';
+
+export const getCountdownText = (date: string, mode: EventMode): string => {
+  const target = new Date(date);
+  if (mode === 'countup') {
+    const distance = formatDistanceToNowStrict(target, { addSuffix: false });
+    return `${distance} since`;
+  }
+
+  if (isPast(target)) {
+    const distance = formatDistanceToNowStrict(target, { addSuffix: false });
+    return `${distance} ago`;
+  }
+
+  const distance = formatDistanceToNowStrict(target, { addSuffix: false });
+  return `${distance} left`;
+};
+
+export const getProgressToEvent = (createdAt: string, date: string, mode: EventMode): number => {
+  if (mode === 'countup') {
+    return 1; // Count ups are always considered complete in terms of progress bar.
+  }
+
+  const created = new Date(createdAt);
+  const target = new Date(date);
+  const now = new Date();
+  if (target.getTime() <= created.getTime()) {
+    return 1;
+  }
+  const totalDuration = target.getTime() - created.getTime();
+  const elapsed = Math.min(Math.max(now.getTime() - created.getTime(), 0), totalDuration);
+  return elapsed / totalDuration;
+};
+
+export const describeTimeDelta = (date: string, mode: EventMode): string => {
+  const target = new Date(date);
+  const now = new Date();
+  if (mode === 'countup') {
+    const days = Math.abs(differenceInDays(now, target));
+    return days === 0 ? 'Today' : `${days} day${days === 1 ? '' : 's'} since`;
+  }
+  const minutes = differenceInMinutes(target, now);
+  if (minutes <= 0) {
+    const hours = Math.abs(differenceInHours(now, target));
+    return hours <= 24 ? 'Moments ago' : `${Math.abs(differenceInDays(now, target))} days ago`;
+  }
+  const hours = Math.ceil(minutes / 60);
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? '' : 's'} left`;
+  }
+  const days = Math.ceil(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} left`;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "App.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Expo React Native project with navigation, theming, and storage
- implement countdown creation, detail, and settings flows with premium handling
- add notification scheduling, sharing, and supporting utilities
- remove bundled PNG icon and splash assets and fall back to Expo defaults

## Testing
- Not run (dependencies not installed in CI container)

------
https://chatgpt.com/codex/tasks/task_e_68da4d63784c8326a0c01748f4740ed6