### PR TITLE
Replace Expo vector icons with custom SVG icons

### DIFF
--- a/app/event/[id].tsx
+++ b/app/event/[id].tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { Alert, ImageBackground, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import { captureRef } from 'react-native-view-shot';
 import * as Sharing from 'expo-sharing';
 import Animated, { FadeInUp } from 'react-native-reanimated';
@@ -9,6 +8,7 @@ import { useEventStore } from '@/store/eventStore';
 import { calculateProgress, formatCountdownText } from '@/utils/time';
 import PrimaryButton from '@/components/PrimaryButton';
 import QuoteBlock from '@/components/QuoteBlock';
+import { BookmarkIcon, ShareIcon } from '@/components/icons';
 
 export default function EventScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -78,8 +78,23 @@ export default function EventScreen() {
           <Text style={styles.timestamp}>{new Date(event.dateTime).toLocaleString()}</Text>
           <QuoteBlock text={event.quote} />
           <View style={styles.actions}>
-            <PrimaryButton label="Share" onPress={handleShare} leading={<Ionicons name="share-outline" size={18} color="#E4F2F0" />} />
-            <PrimaryButton label={event.pinned ? 'Unpin' : 'Pin'} onPress={handlePin} leading={<Ionicons name="bookmark-outline" size={18} color="#E4F2F0" />} />
+            <PrimaryButton
+              label="Share"
+              onPress={handleShare}
+              leading={<ShareIcon size={20} color="#E4F2F0" strokeWidth={1.8} />}
+            />
+            <PrimaryButton
+              label={event.pinned ? 'Unpin' : 'Pin'}
+              onPress={handlePin}
+              leading={
+                <BookmarkIcon
+                  size={20}
+                  color="#E4F2F0"
+                  strokeWidth={1.8}
+                  fill={event.pinned ? 'rgba(228,242,240,0.18)' : 'none'}
+                />
+              }
+            />
           </View>
         </Animated.View>
       </ScrollView>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,11 +2,11 @@ import { useEffect, useMemo } from 'react';
 // Home screen: lists countdown moments and provides quick access to creation & settings.
 import { Link, useNavigation, useRouter } from 'expo-router';
 import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import FloatingActionButton from '@/components/FloatingActionButton';
 import EventCard from '@/components/EventCard';
 import { useEventStore } from '@/store/eventStore';
 import { useSettingsStore } from '@/store/settingsStore';
+import { SettingsIcon } from '@/components/icons';
 
 const sortEvents = (events: ReturnType<typeof useEventStore.getState>['events']) =>
   [...events].sort((a, b) => {
@@ -26,10 +26,10 @@ export default function HomeScreen() {
     navigation.setOptions({
       headerRight: () => (
         <Link href="/settings" asChild>
-          <Ionicons
-            name="settings-outline"
+          <SettingsIcon
             size={22}
             color={theme === 'dark' ? '#F2F4F7' : '#1A1D21'}
+            strokeWidth={1.8}
             style={{ marginRight: 16 }}
           />
         </Link>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "countdown",
       "version": "1.0.0",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@expo/vector-icons": "^14.0.2",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-native-community/datetimepicker": "8.0.1",
         "@tanstack/react-query": "5.51.23",
@@ -38,7 +36,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.24.5",
-        "@babel/plugin-transform-runtime": "^7.28.3",
         "@types/react": "~18.2.79",
         "@types/react-native": "0.73.0",
         "eslint": "8.57.0",
@@ -1663,25 +1660,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
@@ -2001,14 +1979,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2862,16 +2832,6 @@
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw=="
-    },
-    "node_modules/@expo/vector-icons": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.1.0.tgz",
-      "integrity": "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==",
-      "peerDependencies": {
-        "expo-font": "*",
-        "react": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/@expo/xcpretty": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint ."
   },
   "dependencies": {
-    "@babel/runtime": "^7.28.4",
-    "@expo/vector-icons": "^14.0.2",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.0.1",
     "@tanstack/react-query": "5.51.23",
@@ -41,7 +39,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
-    "@babel/plugin-transform-runtime": "^7.28.3",
     "@types/react": "~18.2.79",
     "@types/react-native": "0.73.0",
     "eslint": "8.57.0",

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,68 @@
+import Svg, { Circle, Path } from 'react-native-svg';
+import type { SvgProps } from 'react-native-svg';
+
+interface IconProps extends SvgProps {
+  size?: number;
+  color?: string;
+  strokeWidth?: number;
+}
+
+export const SettingsIcon = ({
+  size = 22,
+  color = '#E4F2F0',
+  strokeWidth = 1.8,
+  ...props
+}: IconProps) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" {...props}>
+    <Path d="M4 7h16" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" />
+    <Path d="M4 12h16" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" />
+    <Path d="M4 17h16" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" />
+    <Circle cx={8} cy={7} r={2.4} stroke={color} strokeWidth={strokeWidth} fill="none" />
+    <Circle cx={15} cy={12} r={2.4} stroke={color} strokeWidth={strokeWidth} fill="none" />
+    <Circle cx={10} cy={17} r={2.4} stroke={color} strokeWidth={strokeWidth} fill="none" />
+  </Svg>
+);
+
+export const ShareIcon = ({
+  size = 20,
+  color = '#E4F2F0',
+  strokeWidth = 1.8,
+  ...props
+}: IconProps) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" {...props}>
+    <Path
+      d="M7 11.5 12 6l5 5.5"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <Path d="M12 6v12" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" />
+    <Path
+      d="M5 20h14"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export const BookmarkIcon = ({
+  size = 20,
+  color = '#E4F2F0',
+  strokeWidth = 1.8,
+  fill = 'none',
+  ...props
+}: IconProps) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" {...props}>
+    <Path
+      d="M7 3.5h10c.83 0 1.5.67 1.5 1.5v15l-6.5-3.2L5.5 20V5c0-.83.67-1.5 1.5-1.5Z"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill={fill}
+    />
+  </Svg>
+);


### PR DESCRIPTION
## Summary
- replace usage of Expo vector icons with custom SVG implementations for settings, share, and bookmark actions
- add a shared icons module and update screens to consume the SVG icons so no font loading is required
- drop direct dependencies on `@expo/vector-icons`, `@babel/runtime`, and its transform plugin from the project manifests

## Testing
- npm run lint *(fails: ESLint couldn't find the config "universe/native" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68deeecbd1948326913f75843e4ba62c